### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::openai::profile::off()`
 - `p6df::modules::openai::profile::on(profile, code_env)`
   - Args:
-    - profile - 
-    - code_env - 
+    - profile -
+    - code_env -
 - `p6df::modules::openai::vscodes()`
 - `str str = p6df::modules::openai::prompt::mod()`
 

--- a/init.zsh
+++ b/init.zsh
@@ -50,7 +50,7 @@ p6df::modules::openai::external::brews() {
 ######################################################################
 p6df::modules::openai::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-openai/share/codex" .codex
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-openai/share/codex" "$HOME/.codex"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.