### PR TITLE
fix(openai): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -48,5 +48,5 @@ p6df::modules::openai::mcp::server::add() {
 p6df::modules::openai::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'openai' "$OPENAI_API_KEY"
+  p6_return_words 'openai' '$OPENAI_API_KEY'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None